### PR TITLE
fix: replace stale Gatsby service worker with self-destroying worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,20 @@
+// Self-destroying service worker. The previous Gatsby site
+// (gatsby-plugin-offline) registered a worker at this path that keeps serving
+// its cached app shell to returning visitors, who then see a blank page. This
+// replacement takes over immediately, wipes every cache it left behind, and
+// reloads open tabs so the current site is fetched from the network.
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+      await self.registration.unregister();
+      const clients = await self.clients.matchAll({ type: "window" });
+      clients.forEach((client) => client.navigate(client.url));
+    })(),
+  );
+});

--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+
+import { expect, test } from "vitest";
+
+// The old Gatsby site (gatsby-plugin-offline) registered a service worker at
+// /sw.js. Returning browsers are served the stale cached app shell, which
+// fails to boot against the Astro site and renders a blank page. A
+// self-destroying worker at the same path must replace it, clear its caches,
+// and reload open tabs.
+test("public/sw.js self-destroys the stale gatsby service worker", () => {
+  const sw = readFileSync("public/sw.js", "utf-8");
+  expect(sw).toContain("skipWaiting()");
+  expect(sw).toContain("caches.keys()");
+  expect(sw).toContain("caches.delete");
+  expect(sw).toContain("client.navigate(client.url)");
+});


### PR DESCRIPTION
Issue:

## Summary

Astro 이전(#239) 후 재방문 브라우저에서 블로그가 빈 화면으로 뜨는 문제를 self-destroying service worker로 해결.

- **증상**: 옛 Gatsby 블로그를 방문했던 브라우저로 접속 시 빈 화면
- **수정**: 같은 경로(`/sw.js`)에 자기 파괴형 service worker 배포
- **효과**: 첫 재방문 즉시 옛 워커·캐시 제거, 이후 새 사이트 정상 로드

## Background

- **원인**: 옛 사이트의 gatsby-plugin-offline이 등록한 service worker가 방문자 브라우저에 잔류
- **동작**: 잔류 워커가 캐시된 Gatsby 앱 셸을 응답 → 존재하지 않는 `page-data.json` 요청 실패 → 빈 화면
- **공백**: 새 사이트에서 `/sw.js`는 404라 옛 워커를 해제할 코드가 전무

## Changes

- **`public/sw.js` 추가**: self-destroying service worker
  - **즉시 교체**: `skipWaiting()`으로 옛 워커 대체
  - **캐시 정리**: 남은 캐시 전부 삭제
  - **자기 해제**: 자기 자신 unregister
  - **화면 복구**: 열린 탭을 `client.navigate`로 새로고침
- **`src/sw.test.ts` 추가**: 워커 필수 동작 존재를 검증하는 vitest 테스트

## Test

- [x] `npx vitest run` — 10 files / 47 tests 전부 통과
- [x] `npm run build` 성공, `dist/sw.js` 산출 확인
