### PR TITLE
chore: fix all build deprecation warnings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import sitemap from "@astrojs/sitemap";
 import autoprefixer from "autoprefixer";
 import lost from "lost";
@@ -22,15 +23,20 @@ export default defineConfig({
   integrations: [sitemap()],
   markdown: {
     syntaxHighlight: "prism",
-    rehypePlugins: [
-      rehypeSlug,
-      rehypeAutolinkGatsby,
-      rehypeInlineCode,
-      [
-        rehypeExternalLinks,
-        { target: "_blank", rel: ["nofollow", "noopener", "noreferrer"] },
+    // The top-level markdown.rehypePlugins option is deprecated since Astro 7
+    // (Sätteri is the default pipeline); these plugins need the unified()
+    // processor from @astrojs/markdown-remark.
+    processor: unified({
+      rehypePlugins: [
+        rehypeSlug,
+        rehypeAutolinkGatsby,
+        rehypeInlineCode,
+        [
+          rehypeExternalLinks,
+          { target: "_blank", rel: ["nofollow", "noopener", "noreferrer"] },
+        ],
       ],
-    ],
+    }),
   },
   vite: {
     css: {

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -1,4 +1,4 @@
 @charset "UTF-8";
 
-@import "base/generic";
-@import "base/prism";
+@use "base/generic";
+@use "base/prism";

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -1,7 +1,9 @@
 @charset "UTF-8";
 
-@import "mixins/breakpoints";
-@import "mixins/line-height";
-@import "mixins/keyframes";
-@import "mixins/padding";
-@import "mixins/margin";
+// Barrel module: re-export every mixin so consumers can `@use "…/mixins"` and
+// call them under the single `mixins.` namespace.
+@forward "mixins/breakpoints";
+@forward "mixins/line-height";
+@forward "mixins/keyframes";
+@forward "mixins/padding";
+@forward "mixins/margin";

--- a/src/assets/scss/_themes.scss
+++ b/src/assets/scss/_themes.scss
@@ -1,4 +1,4 @@
 @charset "UTF-8";
 
-@import "themes/light";
-@import "themes/dark";
+@use "themes/light";
+@use "themes/dark";

--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -1,18 +1,22 @@
-@import "../variables";
-@import "../mixins";
+@use "../variables";
+@use "../mixins";
+@use "../mixins/breakpoints";
+@use "../mixins/line-height";
+@use "../mixins/margin";
+@use "../mixins/padding";
 
 html {
-  font-size: $typographic-root-font-size;
+  font-size: variables.$typographic-root-font-size;
 }
 
 body {
   background: var(--color-page-background);
   color: var(--color-typographic-base-font);
-  font-family: $typographic-font-family;
-  font-size: $typographic-base-font-size;
+  font-family: variables.$typographic-font-family;
+  font-size: variables.$typographic-base-font-size;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  line-height: $typographic-base-line-height;
+  line-height: variables.$typographic-base-line-height;
   margin: 0 0 0 calc(100vw - 100%);
   text-rendering: optimizelegibility;
   -ms-text-size-adjust: 100%;
@@ -25,50 +29,50 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $typographic-font-family;
+  font-family: variables.$typographic-font-family;
   font-weight: 600;
 }
 
 h1 {
-  font-size: $typographic-base-font-size * 2.5;
-  @include line-height(2);
-  @include margin-top(4);
-  @include margin-bottom(1);
+  font-size: variables.$typographic-base-font-size * 2.5;
+  @include line-height.line-height(2);
+  @include margin.margin-top(4);
+  @include margin.margin-bottom(1);
 }
 
 h2 {
-  font-size: $typographic-base-font-size * 1.6875;
-  @include line-height(1.5);
-  @include margin-top(2);
-  @include margin-bottom(0.5);
+  font-size: variables.$typographic-base-font-size * 1.6875;
+  @include line-height.line-height(1.5);
+  @include margin.margin-top(2);
+  @include margin.margin-bottom(0.5);
 }
 
 h3 {
-  font-size: $typographic-base-font-size * 1.375;
-  @include line-height(1.3);
-  @include margin-top(1);
-  @include margin-bottom(0.5);
+  font-size: variables.$typographic-base-font-size * 1.375;
+  @include line-height.line-height(1.3);
+  @include margin.margin-top(1);
+  @include margin.margin-bottom(0.5);
 }
 
 h4 {
-  font-size: $typographic-base-font-size * 1.2;
-  @include line-height(1);
-  @include margin-top(1.5);
-  @include margin-bottom(0.5);
+  font-size: variables.$typographic-base-font-size * 1.2;
+  @include line-height.line-height(1);
+  @include margin.margin-top(1.5);
+  @include margin.margin-bottom(0.5);
 }
 
 h5 {
-  font-size: $typographic-base-font-size;
-  @include line-height(1);
-  @include margin-top(2.5);
-  @include margin-bottom(0.5);
+  font-size: variables.$typographic-base-font-size;
+  @include line-height.line-height(1);
+  @include margin.margin-top(2.5);
+  @include margin.margin-bottom(0.5);
 }
 
 h6 {
-  font-size: $typographic-base-font-size;
-  @include line-height(1);
-  @include margin-top(2.5);
-  @include margin-bottom(0.5);
+  font-size: variables.$typographic-base-font-size;
+  @include line-height.line-height(1);
+  @include margin.margin-top(2.5);
+  @include margin.margin-bottom(0.5);
 }
 
 img {
@@ -81,8 +85,8 @@ hr {
   background-image: linear-gradient(to bottom,
       transparent 1px,
       transparent 11px,
-      $color-dark 11px,
-      $color-dark 15px,
+      variables.$color-dark 11px,
+      variables.$color-dark 15px,
       transparent 15px,
       transparent 26px);
   background-size: 100% 26px;
@@ -120,27 +124,27 @@ ol {
 
 ul,
 ol {
-  @include margin-bottom(1);
+  @include margin.margin-bottom(1);
   margin-top: 0;
 
   & li {
     padding: 0 5px;
 
     &+li {
-      @include margin-top(0.32);
+      @include margin.margin-top(0.32);
     }
   }
 
   & ul,
   & ol {
     margin-bottom: 0;
-    @include margin-top(0.32);
+    @include margin.margin-top(0.32);
   }
 }
 
 p {
-  @include line-height(1);
-  @include margin-bottom(1);
+  @include line-height.line-height(1);
+  @include margin.margin-bottom(1);
 }
 
 blockquote {
@@ -156,21 +160,21 @@ figure {
 }
 
 figcaption {
-  @include line-height(0.75);
-  @include margin-top(0.25);
+  @include line-height.line-height(0.75);
+  @include margin.margin-top(0.25);
   color: var(--color-typographic-base-font);
-  font-size: $typographic-small-font-size;
+  font-size: variables.$typographic-small-font-size;
   font-style: italic;
   margin-bottom: 0;
   text-align: center;
 }
 
-@include breakpoint-sm {
+@include breakpoints.breakpoint-sm {
 
   figure.float-left,
   figure.float-right {
     max-width: 310px;
-    @include padding(0, 1, 0, 1);
+    @include padding.padding(0, 1, 0, 1);
   }
 
   .float-right {

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -1,8 +1,8 @@
 @charset "UTF-8";
 
-@import "variables";
-@import "themes";
-@import "mixins";
-@import "base";
-@import "base/anchor";
-@import "base/images";
+@use "variables";
+@use "themes";
+@use "mixins";
+@use "base";
+@use "base/anchor";
+@use "base/images";

--- a/src/assets/scss/mixins/_breakpoints.scss
+++ b/src/assets/scss/mixins/_breakpoints.scss
@@ -1,23 +1,23 @@
-@import "../variables";
+@use "../variables";
 
 @mixin breakpoint-xs {
   @content;
 }
 
 @mixin breakpoint-sm {
-  @media screen and (min-width: $layout-breakpoint-sm) {
+  @media screen and (min-width: variables.$layout-breakpoint-sm) {
     @content;
   }
 }
 
 @mixin breakpoint-md {
-  @media screen and (min-width: $layout-breakpoint-md) {
+  @media screen and (min-width: variables.$layout-breakpoint-md) {
     @content;
   }
 }
 
 @mixin breakpoint-lg {
-  @media screen and (min-width: $layout-breakpoint-lg) {
+  @media screen and (min-width: variables.$layout-breakpoint-lg) {
     @content;
   }
 }

--- a/src/assets/scss/mixins/_line-height.scss
+++ b/src/assets/scss/mixins/_line-height.scss
@@ -1,5 +1,5 @@
-@import "../variables";
+@use "../variables";
 
 @mixin line-height($number) {
-  line-height: #{$number * $typographic-leading + "px"};
+  line-height: #{$number * variables.$typographic-leading + "px"};
 }

--- a/src/assets/scss/mixins/_margin.scss
+++ b/src/assets/scss/mixins/_margin.scss
@@ -1,44 +1,44 @@
-@import "../variables";
+@use "../variables";
 
 @mixin margin-auto($number: 0) {
-  margin: #{$number * $typographic-leading + "px"} auto;
+  margin: #{$number * variables.$typographic-leading + "px"} auto;
 }
 
 @mixin margin-left($number) {
-  margin-left: #{$number * $typographic-leading + "px"};
+  margin-left: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin margin-right($number) {
-  margin-right: #{$number * $typographic-leading + "px"};
+  margin-right: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin margin-top($number) {
-  margin-top: #{$number * $typographic-leading + "px"};
+  margin-top: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin margin-bottom($number) {
-  margin-bottom: #{$number * $typographic-leading + "px"};
+  margin-bottom: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin margin-equal($number) {
-  margin: #{$number * $typographic-leading + "px"};
+  margin: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin margin($top, $right, $bottom: null, $left: null) {
   @if not $left and not $bottom {
     margin:
-      #{$top * $typographic-leading + "px"}
-      #{$right * $typographic-leading + "px"};
+      #{$top * variables.$typographic-leading + "px"}
+      #{$right * variables.$typographic-leading + "px"};
   } @else if not $left or $left == $right {
     margin:
-      #{$top * $typographic-leading + "px"}
-      #{$right * $typographic-leading + "px"}
-      #{$bottom * $typographic-leading + "px"};
+      #{$top * variables.$typographic-leading + "px"}
+      #{$right * variables.$typographic-leading + "px"}
+      #{$bottom * variables.$typographic-leading + "px"};
   } @else {
     margin:
-      #{$top * $typographic-leading + "px"}
-      #{$right * $typographic-leading + "px"}
-      #{$bottom * $typographic-leading + "px"}
-      #{$left * $typographic-leading + "px"};
+      #{$top * variables.$typographic-leading + "px"}
+      #{$right * variables.$typographic-leading + "px"}
+      #{$bottom * variables.$typographic-leading + "px"}
+      #{$left * variables.$typographic-leading + "px"};
   }
 }

--- a/src/assets/scss/mixins/_padding.scss
+++ b/src/assets/scss/mixins/_padding.scss
@@ -1,40 +1,40 @@
-@import "../variables";
+@use "../variables";
 
 @mixin padding-left($number) {
-  padding-left: #{$number * $typographic-leading + "px"};
+  padding-left: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin padding-right($number) {
-  padding-right: #{$number * $typographic-leading + "px"};
+  padding-right: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin padding-top($number) {
-  padding-top: #{$number * $typographic-leading + "px"};
+  padding-top: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin padding-bottom($number) {
-  padding-bottom: #{$number * $typographic-leading + "px"};
+  padding-bottom: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin padding-equal($number) {
-  padding: #{$number * $typographic-leading + "px"};
+  padding: #{$number * variables.$typographic-leading + "px"};
 }
 
 @mixin padding($top, $right, $bottom: null, $left: null) {
   @if not $left and not $bottom {
     padding:
-      #{$top * $typographic-leading + "px"}
-      #{$right * $typographic-leading + "px"};
+      #{$top * variables.$typographic-leading + "px"}
+      #{$right * variables.$typographic-leading + "px"};
   } @else if not $left or $left == $right {
     padding:
-      #{$top * $typographic-leading + "px"}
-      #{$right * $typographic-leading + "px"}
-      #{$bottom * $typographic-leading + "px"};
+      #{$top * variables.$typographic-leading + "px"}
+      #{$right * variables.$typographic-leading + "px"}
+      #{$bottom * variables.$typographic-leading + "px"};
   } @else {
     padding:
-      #{$top * $typographic-leading + "px"}
-      #{$right * $typographic-leading + "px"}
-      #{$bottom * $typographic-leading + "px"}
-      #{$left * $typographic-leading + "px"};
+      #{$top * variables.$typographic-leading + "px"}
+      #{$right * variables.$typographic-leading + "px"}
+      #{$bottom * variables.$typographic-leading + "px"}
+      #{$left * variables.$typographic-leading + "px"};
   }
 }

--- a/src/assets/scss/themes/_dark.scss
+++ b/src/assets/scss/themes/_dark.scss
@@ -1,23 +1,23 @@
 @use "sass:color";
-@import "../variables";
+@use "../variables";
 
 :root.dark,
 .dark *:after,
 .dark *:before {
-  --color-white: #{$color-white};
-  --color-primary: #{$color-sky-blue};
-  --color-secondary: #{$color-blue};
-  --color-prism-background: #{$color-dark-paper};
-  --color-typographic-base-font: #{$color-white};
-  --color-typographic-link-p-font: #{$color-sky-blue};
-  --color-typographic-link-s-font: #{$color-blue};
-  --color-page-border: #{$color-dark-cloud};
-  --color-page-background: #{$color-dark};
-  --color-sidebar-border: #{$color-dark-cloud};
-  --color-sidebar-border-fade: #{$color-dark};
-  --color-contacts-border: #{$color-dark-cloud};
-  --color-button-border: #{$color-dark-cloud};
-  --color-button-color: #{$color-white};
-  --color-theme-switcher: #{$color-white-cloud};
-  --color-theme-switcher-hover: #{$color-blue};
+  --color-white: #{variables.$color-white};
+  --color-primary: #{variables.$color-sky-blue};
+  --color-secondary: #{variables.$color-blue};
+  --color-prism-background: #{variables.$color-dark-paper};
+  --color-typographic-base-font: #{variables.$color-white};
+  --color-typographic-link-p-font: #{variables.$color-sky-blue};
+  --color-typographic-link-s-font: #{variables.$color-blue};
+  --color-page-border: #{variables.$color-dark-cloud};
+  --color-page-background: #{variables.$color-dark};
+  --color-sidebar-border: #{variables.$color-dark-cloud};
+  --color-sidebar-border-fade: #{variables.$color-dark};
+  --color-contacts-border: #{variables.$color-dark-cloud};
+  --color-button-border: #{variables.$color-dark-cloud};
+  --color-button-color: #{variables.$color-white};
+  --color-theme-switcher: #{variables.$color-white-cloud};
+  --color-theme-switcher-hover: #{variables.$color-blue};
 }

--- a/src/assets/scss/themes/_light.scss
+++ b/src/assets/scss/themes/_light.scss
@@ -1,23 +1,23 @@
 @use "sass:color";
-@import "../variables";
+@use "../variables";
 
 :root,
 :after,
 :before {
-  --color-white: #{$color-white};
-  --color-primary: #{$color-sky-blue};
-  --color-secondary: #{$color-blue};
-  --color-prism-background: #{$color-white-cloud};
-  --color-typographic-base-font: #{$color-dark};
-  --color-typographic-link-p-font: #{$color-sky-blue};
-  --color-typographic-link-s-font: #{$color-blue};
-  --color-page-border: #{$color-white-cloud};
-  --color-page-background: #{$color-white};
-  --color-sidebar-border: #{$color-white-cloud};
-  --color-sidebar-border-fade: #{$color-white};
-  --color-contacts-border: #{$color-white-cloud};
-  --color-button-border: #{$color-white-cloud};
-  --color-button-color: #{$color-dark};
-  --color-theme-switcher: #{$color-dark-cloud};
-  --color-theme-switcher-hover: #{$color-blue};
+  --color-white: #{variables.$color-white};
+  --color-primary: #{variables.$color-sky-blue};
+  --color-secondary: #{variables.$color-blue};
+  --color-prism-background: #{variables.$color-white-cloud};
+  --color-typographic-base-font: #{variables.$color-dark};
+  --color-typographic-link-p-font: #{variables.$color-sky-blue};
+  --color-typographic-link-s-font: #{variables.$color-blue};
+  --color-page-border: #{variables.$color-white-cloud};
+  --color-page-background: #{variables.$color-white};
+  --color-sidebar-border: #{variables.$color-white-cloud};
+  --color-sidebar-border-fade: #{variables.$color-white};
+  --color-contacts-border: #{variables.$color-white-cloud};
+  --color-button-border: #{variables.$color-white-cloud};
+  --color-button-color: #{variables.$color-dark};
+  --color-theme-switcher: #{variables.$color-dark-cloud};
+  --color-theme-switcher-hover: #{variables.$color-blue};
 }

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -1,23 +1,23 @@
-@import "src/assets/scss/variables";
-@import "src/assets/scss/mixins";
+@use "src/assets/scss/variables";
+@use "src/assets/scss/mixins";
 
 .button {
   border: 1px solid var(--color-button-border);
-  border-radius: $button-border-radius;
+  border-radius: variables.$button-border-radius;
   color: var(--color-button-color);
   display: inline-block;
-  font-size: $typographic-base-font-size;
+  font-size: variables.$typographic-base-font-size;
   font-weight: normal;
-  height: $button-height;
-  line-height: $button-height;
+  height: variables.$button-height;
+  line-height: variables.$button-height;
   margin-left: auto;
   margin-right: auto;
   text-align: center;
   text-decoration: none;
-  @include padding(0, 1);
+  @include mixins.padding(0, 1);
 
   &:hover,
   &:focus {
-    color: $color-blue;
+    color: variables.$color-blue;
   }
 }

--- a/src/components/Feed/Feed.module.scss
+++ b/src/components/Feed/Feed.module.scss
@@ -1,59 +1,61 @@
-@import "../../assets/scss/variables";
-@import "../../assets/scss/mixins";
+@use "../../assets/scss/variables";
+@use "../../assets/scss/mixins";
+@use "src/assets/scss/mixins/line-height";
+@use "src/assets/scss/mixins/margin";
 
 .feed {
   .item {
-    @include margin-bottom(1.25);
+    @include margin.margin-bottom(1.25);
 
     &:last-child {
-      @include margin-bottom(0.5);
+      @include margin.margin-bottom(0.5);
     }
 
     .title {
-      font-size: $typographic-base-font-size * 1.6875;
-      @include line-height(1.5);
-      @include margin-top(0);
-      @include margin-bottom(0.5);
+      font-size: variables.$typographic-base-font-size * 1.6875;
+      @include line-height.line-height(1.5);
+      @include margin.margin-top(0);
+      @include margin.margin-bottom(0.5);
 
       .link {
         color: var(--color-typographic-base-font);
 
         &:hover,
         &:focus {
-          border-bottom: 1px solid $color-dark;
+          border-bottom: 1px solid variables.$color-dark;
           color: var(--color-typographic-base-font);
         }
       }
     }
 
     .description {
-      font-size: $typographic-base-font-size;
-      @include line-height(1);
-      @include margin-bottom(0.75);
+      font-size: variables.$typographic-base-font-size;
+      @include line-height.line-height(1);
+      @include margin.margin-bottom(0.75);
     }
 
     .meta {
       .time {
         color: var(--color-typographic-base-font);
-        font-size: $typographic-small-font-size;
+        font-size: variables.$typographic-small-font-size;
         font-weight: 600;
         text-transform: uppercase;
       }
 
       .divider {
-        @include margin(0, 0.5);
+        @include margin.margin(0, 0.5);
       }
 
       .category {
         .link {
           color: var(--color-secondary);
-          font-size: $typographic-small-font-size;
+          font-size: variables.$typographic-small-font-size;
           font-weight: 600;
           text-transform: uppercase;
 
           &:hover,
           &:focus {
-            color: $color-blue;
+            color: variables.$color-blue;
           }
         }
       }
@@ -61,11 +63,11 @@
 
     .more {
       color: var(--color-primary);
-      font-size: $typographic-base-font-size;
+      font-size: variables.$typographic-base-font-size;
 
       &:hover,
       &:focus {
-        border-bottom: 1px solid $color-blue;
+        border-bottom: 1px solid variables.$color-blue;
         color: var(--color-primary);
       }
     }

--- a/src/components/Layout/Layout.module.scss
+++ b/src/components/Layout/Layout.module.scss
@@ -1,6 +1,6 @@
-@import "../../assets/scss/variables";
-@import "../../assets/scss/mixins";
+@use "../../assets/scss/variables";
+@use "../../assets/scss/mixins";
 
 .layout {
-  lost-center: $layout-width;
+  lost-center: variables.$layout-width;
 }

--- a/src/components/Page/Page.module.scss
+++ b/src/components/Page/Page.module.scss
@@ -1,44 +1,48 @@
-@import "../../assets/scss/variables";
-@import "../../assets/scss/mixins";
+@use "../../assets/scss/variables";
+@use "../../assets/scss/mixins";
+@use "src/assets/scss/mixins/breakpoints";
+@use "src/assets/scss/mixins/line-height";
+@use "src/assets/scss/mixins/margin";
+@use "src/assets/scss/mixins/padding";
 
 .page {
-  @include margin-bottom(2);
+  @include margin.margin-bottom(2);
 
   .inner {
-    @include padding(1, 0.75, 0);
+    @include padding.padding(1, 0.75, 0);
   }
 
   .title {
-    font-size: $typographic-base-font-size * 2.5;
+    font-size: variables.$typographic-base-font-size * 2.5;
     font-weight: 600;
-    @include line-height(2);
-    @include margin-top(0);
-    @include margin-bottom(1.45);
+    @include line-height.line-height(2);
+    @include margin.margin-top(0);
+    @include margin.margin-bottom(1.45);
   }
 
   .body {
-    font-size: $typographic-base-font-size;
-    @include line-height(1);
-    @include margin(0, 0, 1);
+    font-size: variables.$typographic-base-font-size;
+    @include line-height.line-height(1);
+    @include margin.margin(0, 0, 1);
   }
 }
 
-@include breakpoint-sm {
+@include breakpoints.breakpoint-sm {
   .page {
     lost-column: 7/12;
 
     .inner {
-      @include padding(1.25, 0.75, 0);
+      @include padding.padding(1.25, 0.75, 0);
     }
   }
 }
 
-@include breakpoint-md {
+@include breakpoints.breakpoint-md {
   .page {
     lost-column: 2/3;
 
     .inner {
-      @include padding(1.5, 1, 0);
+      @include padding.padding(1.5, 1, 0);
     }
   }
 }

--- a/src/components/Pagination/Pagination.module.scss
+++ b/src/components/Pagination/Pagination.module.scss
@@ -1,11 +1,12 @@
 @use "sass:color";
 
-@import "../../assets/scss/variables";
-@import "../../assets/scss/mixins";
+@use "../../assets/scss/variables";
+@use "../../assets/scss/mixins";
+@use "src/assets/scss/mixins/margin";
 
 .pagination {
   display: flex;
-  @include margin-top(2);
+  @include margin.margin-top(2);
 
   .previous {
     text-align: left;
@@ -22,7 +23,7 @@
       }
 
       &.disable {
-        color: $color-dark-cloud;
+        color: variables.$color-dark-cloud;
         pointer-events: none;
       }
     }
@@ -43,7 +44,7 @@
       }
 
       &.disable {
-        color: $color-dark-cloud;
+        color: variables.$color-dark-cloud;
         pointer-events: none;
       }
     }

--- a/src/components/Post/Content/Content.module.scss
+++ b/src/components/Post/Content/Content.module.scss
@@ -1,39 +1,43 @@
-@import "../../../assets/scss/variables";
-@import "../../../assets/scss/mixins";
+@use "../../../assets/scss/variables";
+@use "../../../assets/scss/mixins";
+@use "src/assets/scss/mixins/breakpoints";
+@use "src/assets/scss/mixins/line-height";
+@use "src/assets/scss/mixins/margin";
+@use "src/assets/scss/mixins/padding";
 
 .content {
-  @include margin-auto();
-  max-width: $layout-post-single-width;
-  @include padding(0, 0.5);
+  @include margin.margin-auto();
+  max-width: variables.$layout-post-single-width;
+  @include padding.padding(0, 0.5);
 
   .title {
-    font-size: $typographic-base-font-size * 2;
+    font-size: variables.$typographic-base-font-size * 2;
     font-weight: 600;
     margin-left: auto;
     margin-right: auto;
-    max-width: $layout-post-width;
+    max-width: variables.$layout-post-width;
     text-align: center;
-    @include line-height(1.65);
-    @include margin-top(1);
-    @include margin-bottom(0);
+    @include line-height.line-height(1.65);
+    @include margin.margin-top(1);
+    @include margin.margin-bottom(0);
   }
 
   .body {
     figure {
-      @include margin-bottom(1);
+      @include margin.margin-bottom(1);
 
       blockquote {
         font-style: italic;
         text-align: center;
-        @include margin-top(0);
-        @include padding(1, 0);
+        @include margin.margin-top(0);
+        @include padding.padding(1, 0);
 
         p {
-          font-size: $typographic-base-font-size * 1.6817;
-          max-width: $layout-post-width;
-          @include margin-top(0);
-          @include margin-bottom(1);
-          @include line-height(1.5);
+          font-size: variables.$typographic-base-font-size * 1.6817;
+          max-width: variables.$layout-post-width;
+          @include margin.margin-top(0);
+          @include margin.margin-bottom(1);
+          @include line-height.line-height(1.5);
         }
       }
     }
@@ -45,7 +49,7 @@
     * {
       margin-left: auto;
       margin-right: auto;
-      max-width: $layout-post-width;
+      max-width: variables.$layout-post-width;
     }
 
     h2 > a {
@@ -62,31 +66,31 @@
   }
 }
 
-@include breakpoint-md {
+@include breakpoints.breakpoint-md {
   .content {
-    @include padding-equal(0);
+    @include padding.padding-equal(0);
 
     .title {
-      font-size: $typographic-base-font-size * 3;
-      @include line-height(2.25);
-      @include margin-top(2.25);
-      @include margin-bottom(1.5);
+      font-size: variables.$typographic-base-font-size * 3;
+      @include line-height.line-height(2.25);
+      @include margin.margin-top(2.25);
+      @include margin.margin-bottom(1.5);
     }
 
     .body {
-      font-size: $typographic-base-font-size * 1.125;
-      @include line-height(1.125);
-      @include margin-bottom(1.125);
+      font-size: variables.$typographic-base-font-size * 1.125;
+      @include line-height.line-height(1.125);
+      @include margin.margin-bottom(1.125);
 
       p {
-        font-size: $typographic-base-font-size * 1.125;
-        @include line-height(1.125);
-        @include margin-bottom(1.125);
+        font-size: variables.$typographic-base-font-size * 1.125;
+        @include line-height.line-height(1.125);
+        @include margin.margin-bottom(1.125);
       }
 
       h2 > a {
         visibility: unset;
-        @include padding-right(0.5);
+        @include padding.padding-right(0.5);
       }
     }
   }

--- a/src/components/Post/Meta/Meta.module.scss
+++ b/src/components/Post/Meta/Meta.module.scss
@@ -1,5 +1,5 @@
-@import "../../../assets/scss/variables";
-@import "../../../assets/scss/mixins";
+@use "../../../assets/scss/variables";
+@use "../../../assets/scss/mixins";
 
 .meta {
   .date {

--- a/src/components/Post/Post.module.scss
+++ b/src/components/Post/Post.module.scss
@@ -1,21 +1,21 @@
-@import "src/assets/scss/variables";
-@import "src/assets/scss/mixins";
+@use "src/assets/scss/variables";
+@use "src/assets/scss/mixins";
 
 .post {
   .content {
-    @include margin-auto();
+    @include mixins.margin-auto();
   }
 
   .footer {
-    max-width: $layout-post-width;
-    @include padding(0, 0.5);
-    @include margin-auto();
+    max-width: variables.$layout-post-width;
+    @include mixins.padding(0, 0.5);
+    @include mixins.margin-auto();
   }
 
   .comments {
-    max-width: $layout-post-width;
-    @include padding(0, 0.5);
-    @include margin-auto();
+    max-width: variables.$layout-post-width;
+    @include mixins.padding(0, 0.5);
+    @include mixins.margin-auto();
   }
 
   .buttons {
@@ -23,22 +23,22 @@
     display: flex;
     justify-content: center;
     text-align: center;
-    @include margin(1, 0, 0, 0);
+    @include mixins.margin(1, 0, 0, 0);
 
     .buttonArticles {
-      @include margin(0, 0.5, 0, 0);
+      @include mixins.margin(0, 0.5, 0, 0);
     }
   }
 }
 
-@include breakpoint-md {
+@include mixins.breakpoint-md {
   .post {
     .footer {
-      @include padding-equal(0);
+      @include mixins.padding-equal(0);
     }
 
     .comments {
-      @include padding-equal(0);
+      @include mixins.padding-equal(0);
     }
 
     .buttons {
@@ -46,7 +46,7 @@
       max-width: none;
       position: fixed;
       top: 30px;
-      @include margin(0, 0.5, 0, 0);
+      @include mixins.margin(0, 0.5, 0, 0);
     }
   }
 }

--- a/src/components/Post/Tags/Tags.module.scss
+++ b/src/components/Post/Tags/Tags.module.scss
@@ -1,21 +1,24 @@
-@import "../../../assets/scss/variables";
-@import "../../../assets/scss/mixins";
+@use "../../../assets/scss/variables";
+@use "../../../assets/scss/mixins";
+@use "src/assets/scss/mixins/breakpoints";
+@use "src/assets/scss/mixins/margin";
+@use "src/assets/scss/mixins/padding";
 
 .tags {
-  @include margin-bottom(0.5);
+  @include margin.margin-bottom(0.5);
 
   .list {
     list-style: none;
-    @include padding-equal(0);
+    @include padding.padding-equal(0);
 
     .item {
       display: inline-block;
-      @include margin(0.25, 0);
+      @include margin.margin(0.25, 0);
 
-      @include breakpoint-sm {
+      @include breakpoints.breakpoint-sm {
         &:first-child {
-          @include margin-left(0);
-          @include padding-left(0);
+          @include margin.margin-left(0);
+          @include padding.padding-left(0);
         }
       }
     }

--- a/src/components/Sidebar/Author/Author.module.scss
+++ b/src/components/Sidebar/Author/Author.module.scss
@@ -1,5 +1,7 @@
-@import "../../../assets/scss/variables";
-@import "../../../assets/scss/mixins";
+@use "../../../assets/scss/variables";
+@use "../../../assets/scss/mixins";
+@use "src/assets/scss/mixins/line-height";
+@use "src/assets/scss/mixins/margin";
 
 .author {
   .photo {
@@ -8,7 +10,7 @@
     display: inline-block;
     height: 75px;
     width: 75px;
-    @include margin-bottom(0);
+    @include margin.margin-bottom(0);
 
     img {
       border-radius: 50%;
@@ -16,10 +18,10 @@
   }
 
   .title {
-    font-size: $typographic-base-font-size * 1.125;
+    font-size: variables.$typographic-base-font-size * 1.125;
     font-weight: 600;
     margin: 0;
-    @include line-height(1.125);
+    @include line-height.line-height(1.125);
 
     .link {
       color: var(--color-typographic-base-font);
@@ -32,15 +34,15 @@
   }
 
   .subtitle {
-    color: $color-gray;
-    @include line-height(1);
-    @include margin-bottom(1);
+    color: variables.$color-gray;
+    @include line-height.line-height(1);
+    @include margin.margin-bottom(1);
   }
 
   .titleContainer {
     align-items: center;
     display: flex;
     justify-content: space-between;
-    @include margin(0.5, 0, 0.5, 0);
+    @include margin.margin(0.5, 0, 0.5, 0);
   }
 }

--- a/src/components/Sidebar/Contacts/Contacts.module.scss
+++ b/src/components/Sidebar/Contacts/Contacts.module.scss
@@ -1,8 +1,8 @@
-@import "src/assets/scss/variables";
-@import "src/assets/scss/mixins";
+@use "src/assets/scss/variables";
+@use "src/assets/scss/mixins";
 
 .contacts {
-  @include margin-bottom(1);
+  @include mixins.margin-bottom(1);
 
   .list {
     display: flex;
@@ -11,8 +11,8 @@
     flex-shrink: 0;
     list-style: none;
     max-width: 165px;
-    @include padding-equal(0);
-    @include margin(0.5, 0);
+    @include mixins.padding-equal(0);
+    @include mixins.margin(0.5, 0);
 
     .item {
       align-content: center;
@@ -20,16 +20,16 @@
       border: 1px solid var(--color-contacts-border);
       border-radius: 50%;
       display: flex;
-      height: $button-height;
+      height: variables.$button-height;
       justify-content: center;
-      line-height: $button-height;
+      line-height: variables.$button-height;
       text-align: center;
-      width: $button-height;
-      @include padding-equal(0);
-      @include margin-equal(0.25);
+      width: variables.$button-height;
+      @include mixins.padding-equal(0);
+      @include mixins.margin-equal(0.25);
 
       &:nth-child(3n + 1) {
-        @include margin-left(0);
+        @include mixins.margin-left(0);
       }
 
       .link {

--- a/src/components/Sidebar/Copyright/Copyright.module.scss
+++ b/src/components/Sidebar/Copyright/Copyright.module.scss
@@ -1,9 +1,9 @@
 @use "sass:color";
 
-@import "../../../assets/scss/variables";
-@import "../../../assets/scss/mixins";
+@use "../../../assets/scss/variables";
+@use "../../../assets/scss/mixins";
 
 .copyright {
-  color: $color-gray;
-  font-size: $typographic-small-font-size;
+  color: variables.$color-gray;
+  font-size: variables.$typographic-small-font-size;
 }

--- a/src/components/Sidebar/Menu/Menu.module.scss
+++ b/src/components/Sidebar/Menu/Menu.module.scss
@@ -1,28 +1,30 @@
-@import "../../../assets/scss/variables";
-@import "../../../assets/scss/mixins";
+@use "../../../assets/scss/variables";
+@use "../../../assets/scss/mixins";
+@use "src/assets/scss/mixins/margin";
+@use "src/assets/scss/mixins/padding";
 
 .menu {
-  @include margin-bottom(1);
+  @include margin.margin-bottom(1);
 
   .list {
     list-style: none;
-    @include margin-equal(0);
-    @include padding-equal(0);
+    @include margin.margin-equal(0);
+    @include padding.padding-equal(0);
 
     .item {
-      @include margin(0.5, 0);
-      @include padding-equal(0);
+      @include margin.margin(0.5, 0);
+      @include padding.padding-equal(0);
 
       .link {
         border: 0;
         color: var(--color-typographic-base-font);
-        font-size: $typographic-base-font-size;
+        font-size: variables.$typographic-base-font-size;
         font-weight: normal;
 
         &:hover,
         &:focus {
-          border-bottom: 1px solid $color-blue;
-          color: $color-blue;
+          border-bottom: 1px solid variables.$color-blue;
+          color: variables.$color-blue;
         }
 
         &.active {

--- a/src/components/Sidebar/Sidebar.module.scss
+++ b/src/components/Sidebar/Sidebar.module.scss
@@ -1,10 +1,12 @@
-@import "../../assets/scss/mixins";
+@use "../../assets/scss/mixins";
+@use "src/assets/scss/mixins/breakpoints";
+@use "src/assets/scss/mixins/padding";
 
 .sidebar {
   width: 100%;
 
   .inner {
-    @include padding(1, 0.75, 0);
+    @include padding.padding(1, 0.75, 0);
     position: relative;
 
     &:after {
@@ -19,12 +21,12 @@
   }
 }
 
-@include breakpoint-sm {
+@include breakpoints.breakpoint-sm {
   .sidebar {
     lost-column: 5/12;
 
     .inner {
-      @include padding(1.25, 0.75, 0);
+      @include padding.padding(1.25, 0.75, 0);
 
       &:after {
         bottom: 0;
@@ -39,12 +41,12 @@
   }
 }
 
-@include breakpoint-md {
+@include breakpoints.breakpoint-md {
   .sidebar {
     lost-column: 1/3;
 
     .inner {
-      @include padding-equal(1.5);
+      @include padding.padding-equal(1.5);
     }
   }
 }

--- a/src/components/ThemeSwitcher/ThemeSwitcher.module.scss
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.module.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
-@import "src/assets/scss/mixins";
-@import "src/assets/scss/variables";
+@use "src/assets/scss/mixins";
+@use "src/assets/scss/variables";
 
 .themeSwitcher {
   --color: var(--color-theme-switcher);


### PR DESCRIPTION
Issue: N/A

## Summary

빌드 시 출력되던 deprecation 워닝 2종(Astro markdown 옵션 1건 + Sass `@import` 85건)을 모두 제거. 사이트 출력물은 바이트 단위로 동일.

- **Astro markdown**: deprecated된 top-level `rehypePlugins` 옵션을 `markdown.processor` 방식으로 이전
- **Sass 모듈화**: scss 26개 파일 전부 `@import` → `@use`/`@forward` 마이그레이션
- **출력 무변경**: 빌드 산출물 diff 결과 변경 전과 완전 동일 — 순수 내부 정리

## Background

- **Astro 7 deprecation**: 기본 마크다운 파이프라인이 Sätteri로 바뀌면서 top-level `markdown.rehypePlugins` 옵션이 deprecated됨. 빌드마다 경고 출력
- **Sass `@import` deprecation**: Dart Sass 3.0에서 `@import` 제거 예정. 빌드마다 경고 85건 출력
- 지금 정리해 두지 않으면 이후 메이저 업그레이드 시 빌드가 깨지는 요인이 됨

## Changes

- **markdown processor 이전**: rehype 플러그인을 `@astrojs/markdown-remark`의 `unified()` 프로세서로 감싸 `markdown.processor`로 전달. `syntaxHighlight: "prism"`은 top-level 유지
- **scss 모듈 시스템 전환**: sass-migrator로 scss 26개 파일을 `@use`/`@forward`로 일괄 마이그레이션
- **배럴 파일 수동 교정**: 마이그레이터가 `_mixins.scss`를 `@use`로 변환해 하위 믹스인이 재노출되지 않는 버그가 있어 `@forward`로 수동 수정

## Test

- [x] 빌드 워닝 0건 (`DEPRECATION WARNING`, `[astro] markdown` deprecation 모두 소멸)
- [x] vitest 10 files / 47 tests 전부 통과
- [x] 빌드 산출물(dist) 변경 전후 `diff -r` 전체 비교 — 바이트 단위 완전 동일 (CSS 해시 `BaseLayout.D7N2t0td.css`까지 그대로)
